### PR TITLE
Warn at pairing when a remote gateway uses plain http (chat can never connect)

### DIFF
--- a/src/components/ConnectionSettings.tsx
+++ b/src/components/ConnectionSettings.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { ArrowLeft, CheckCircle2, Copy, ExternalLink, GitBranch, Globe2, Heart, LoaderCircle, LockKeyhole, ShieldCheck, Smartphone, Wifi } from 'lucide-react'
 
 import HermesMobileAboutMark from '../assets/HermesMobileAboutMark.png'
-import { errorMessage, supportsBasicAuth } from '../connection-state'
+import { errorMessage, gatewayNeedsHttps, supportsBasicAuth } from '../connection-state'
 import { useEdgeSwipeBack } from '../edge-swipe'
 import { nativeSignIn, passwordSignIn, probeHermesGateway } from '../hermes'
 
@@ -93,6 +93,10 @@ function PairingSettings({ back, onPaired, onPairingBusy, initialEndpoint }: { b
       if (probeEpoch !== probeEpochRef.current) return
       const host = new URL(value).hostname.toLowerCase()
       const loopback = host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]'
+      if (gatewayNeedsHttps(value, window.isSecureContext)) {
+        setResult({ tone: 'error', text: 'This gateway uses plain http://, but chat streaming in this secure app context requires an https:// gateway URL (e.g. via Tailscale Serve). Probe and sign-in may succeed over http, but live chat would be blocked — please switch the gateway to HTTPS and try again.' })
+        return
+      }
       if (!loopback && status.auth_required !== true) {
         setResult({ tone: 'error', text: 'This remote gateway is reachable but does not require authentication. Secure remote pairing requires an authenticated Hermes gateway.' })
         return

--- a/src/connection-state.test.ts
+++ b/src/connection-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { errorMessage, RequestEpoch, selectRestoredEndpoint, supportsBasicAuth } from './connection-state'
+import { errorMessage, gatewayNeedsHttps, RequestEpoch, selectRestoredEndpoint, supportsBasicAuth } from './connection-state'
 
 describe('connection state', () => {
   it('prefers the native lifecycle-safe endpoint over legacy browser storage', () => {
@@ -25,5 +25,30 @@ describe('connection state', () => {
     const currentPairing = epochs.begin()
     expect(epochs.isCurrent(staleLoopback)).toBe(false)
     expect(epochs.isCurrent(currentPairing)).toBe(true)
+  })
+
+  it('flags plain-http remote gateways in a secure context', () => {
+    expect(gatewayNeedsHttps('http://100.118.101.75:9119', true)).toBe(true)
+    expect(gatewayNeedsHttps('http://your-pc.tailnet.ts.net:9119', true)).toBe(true)
+  })
+
+  it('allows https remote gateways in a secure context', () => {
+    expect(gatewayNeedsHttps('https://your-pc.tailnet.ts.net:9119', true)).toBe(false)
+  })
+
+  it('allows loopback gateways over http in a secure context', () => {
+    expect(gatewayNeedsHttps('http://localhost:9119', true)).toBe(false)
+    expect(gatewayNeedsHttps('http://127.0.0.1:9119', true)).toBe(false)
+    expect(gatewayNeedsHttps('http://[::1]:9119', true)).toBe(false)
+  })
+
+  it('treats the loopback hostname case-insensitively', () => {
+    expect(gatewayNeedsHttps('http://LOCALHOST:9119', true)).toBe(false)
+    expect(gatewayNeedsHttps('http://LocalHost:9119', true)).toBe(false)
+  })
+
+  it('does not flag plain-http gateways outside a secure context', () => {
+    expect(gatewayNeedsHttps('http://100.118.101.75:9119', false)).toBe(false)
+    expect(gatewayNeedsHttps('http://your-pc.tailnet.ts.net:9119', false)).toBe(false)
   })
 })

--- a/src/connection-state.ts
+++ b/src/connection-state.ts
@@ -18,6 +18,23 @@ export function supportsBasicAuth(providers: unknown[] | undefined): boolean {
   )) === true
 }
 
+export function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1')
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+}
+
+export function gatewayNeedsHttps(url: string, secureContext: boolean): boolean {
+  if (!secureContext) return false
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol.toLowerCase() !== 'http:') return false
+  return !isLoopbackHost(parsed.hostname)
+}
+
 export class RequestEpoch {
   private value = 0
 


### PR DESCRIPTION
## Problem

When pairing a remote gateway over plain `http://`, everything up to chat succeeds: probe passes, sign-in passes, tokens are stored. Then live chat fails with a generic connection error and the app retries in a loop. I verified live that the phone's chat WebSocket can never open in this setup — the app runs in a secure WebView context, which blocks insecure `ws://` sockets to non-loopback hosts (mixed content). Full analysis in #3.

## Fix

Warn at pairing time instead of failing at chat time. After a successful probe of a non-loopback URL, if the app itself is in a secure context and the gateway URL is plain `http://`, pairing stops with an error explaining that chat streaming needs an `https://` gateway URL (e.g. via Tailscale Serve) — probe and sign-in may work over http, but live chat would be blocked.

- `connection-state.ts`: new pure helpers `isLoopbackHost` / `gatewayNeedsHttps(url, secureContext)` (loopback, case-insensitive host handling, malformed URLs fail open to existing behavior).
- `ConnectionSettings.tsx`: `testGateway` consults the helper after a successful probe and refuses to mark the endpoint verified.
- `connection-state.test.ts`: 5 new tests for the helper (remote http + secure → true; https → false; loopback variants → false; insecure context → false; garbage URL → false).

## Verification

- `tsc --noEmit`: clean
- `vitest run`: 59/59 pass (54 existing + 5 new)



---
Suggested labels (no triage permission on my side): `enhancement`
