### PR TITLE
Calm chat auto-scroll: one rAF per frame, no redundant state updates

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -8,6 +8,7 @@ import { BotAvatar } from './BotAvatar'
 import { MessageCard, MarkdownContent } from './MarkdownContent'
 import type { ToolActivity } from '../App'
 import { applySlashCompletion } from '../slash-routing'
+import { SCROLL_FOLLOW_THRESHOLD, shouldStickToBottom } from '../scroll-follow'
 import { formatResponseStats } from '../message-stats'
 import { isExpectedVoiceCleanupError, VOICE_AUTOSEND_HOLD_MS } from '../voice-input'
 import { useEdgeSwipeBack } from '../edge-swipe'
@@ -67,6 +68,7 @@ export function ChatView({ session, conversationLoading, messages, settledAssist
   const fileInputRef = useRef<HTMLInputElement>(null)
   const initializedRef = useRef(false)
   const followingRef = useRef(true)
+  const stickQueuedRef = useRef(false)
   const [following, setFollowing] = useState(true)
   const [unreadBelow, setUnreadBelow] = useState(0)
   const [revealedTimestampId, setRevealedTimestampId] = useState<number | null>(null)
@@ -120,9 +122,21 @@ export function ChatView({ session, conversationLoading, messages, settledAssist
     const thread = threadRef.current
     if (!thread) return
     thread.scrollTo({ top: thread.scrollHeight, behavior })
-    followingRef.current = true
-    setFollowing(true)
-    setUnreadBelow(0)
+    if (!followingRef.current) {
+      followingRef.current = true
+      setFollowing(prev => (prev ? prev : true))
+    }
+    setUnreadBelow(prev => (prev === 0 ? prev : 0))
+  }
+
+  const scheduleStickToBottom = (behavior: ScrollBehavior = 'auto') => {
+    if (stickQueuedRef.current) return
+    stickQueuedRef.current = true
+    requestAnimationFrame(() => {
+      stickQueuedRef.current = false
+      if (!followingRef.current) return
+      scrollToLatest(behavior)
+    })
   }
 
   useEffect(() => {
@@ -150,7 +164,7 @@ export function ChatView({ session, conversationLoading, messages, settledAssist
 
   useEffect(() => {
     if (!initializedRef.current) return
-    if (followingRef.current) requestAnimationFrame(() => scrollToLatest('auto'))
+    if (followingRef.current) scheduleStickToBottom('auto')
     else setUnreadBelow(count => count + 1)
   }, [messages.length, streaming])
 
@@ -158,7 +172,7 @@ export function ChatView({ session, conversationLoading, messages, settledAssist
     const content = contentRef.current
     if (!content) return
     const observer = new ResizeObserver(() => {
-      if (followingRef.current) requestAnimationFrame(() => scrollToLatest('auto'))
+      if (followingRef.current) scheduleStickToBottom('auto')
     })
     observer.observe(content)
     return () => observer.disconnect()
@@ -206,10 +220,11 @@ export function ChatView({ session, conversationLoading, messages, settledAssist
   const onScroll = () => {
     const thread = threadRef.current
     if (!thread) return
-    const nearEnd = thread.scrollHeight - thread.scrollTop - thread.clientHeight < 120
+    const nearEnd = shouldStickToBottom(thread.scrollHeight, thread.scrollTop, thread.clientHeight, SCROLL_FOLLOW_THRESHOLD)
+    if (nearEnd === followingRef.current) return
     followingRef.current = nearEnd
     setFollowing(nearEnd)
-    if (nearEnd) setUnreadBelow(0)
+    if (nearEnd) setUnreadBelow(prev => (prev === 0 ? prev : 0))
   }
 
   const pullRefresh = async () => {

--- a/src/scroll-follow.test.ts
+++ b/src/scroll-follow.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { SCROLL_FOLLOW_THRESHOLD, shouldStickToBottom } from './scroll-follow'
+
+describe('shouldStickToBottom', () => {
+  it('sticks when pinned to the bottom', () => {
+    expect(shouldStickToBottom(1000, 800, 200)).toBe(true)
+  })
+
+  it('sticks within the default 120px threshold', () => {
+    expect(shouldStickToBottom(1000, 681, 200)).toBe(true)
+  })
+
+  it('stops sticking when scrolled up past the threshold', () => {
+    expect(shouldStickToBottom(1000, 679, 200)).toBe(false)
+  })
+
+  it('treats exactly-threshold distance as scrolled up (matches < check)', () => {
+    expect(shouldStickToBottom(1000, 680, 200)).toBe(false)
+  })
+
+  it('honours a custom threshold', () => {
+    expect(shouldStickToBottom(1000, 700, 200, 50)).toBe(false)
+    expect(shouldStickToBottom(1000, 760, 200, 50)).toBe(true)
+  })
+
+  it('exposes the default threshold used by ChatView', () => {
+    expect(SCROLL_FOLLOW_THRESHOLD).toBe(120)
+  })
+})

--- a/src/scroll-follow.ts
+++ b/src/scroll-follow.ts
@@ -1,0 +1,10 @@
+export const SCROLL_FOLLOW_THRESHOLD = 120
+
+export function shouldStickToBottom(
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  threshold: number = SCROLL_FOLLOW_THRESHOLD,
+): boolean {
+  return scrollHeight - scrollTop - clientHeight < threshold
+}


### PR DESCRIPTION
## Problem

During streaming, every token fires **two** scroll passes: the `[messages.length, streaming]` effect schedules a `requestAnimationFrame(scrollTo)` and the content `ResizeObserver` schedules another one, plus forced layout reads each time. Separately, `onScroll` calls `setFollowing` on every scroll tick even when nothing changed, re-rendering the chat continuously while the user scrolls.

## Fix

- New `scroll-follow.ts`: pure `shouldStickToBottom(scrollHeight, scrollTop, clientHeight, threshold)` helper (+ exported 120px threshold constant).
- `ChatView`: a `scheduleStickToBottom` schedule-once flag coalesces all scroll requests to at most one rAF per frame; `onScroll` and `scrollToLatest` only touch state when the value actually changes (same-value functional updates so React bails out).
- Semantics unchanged: stick while following, stop + count unread when scrolled up, Latest button, pull-to-refresh all behave as before.

## Verification

- `tsc --noEmit`: clean
- `vitest run`: 60/60 pass (54 existing + 6 new scroll-follow tests)



---
Suggested labels (no triage permission on my side): `performance`
